### PR TITLE
Clearer installation instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,26 @@ Install OrsaySuite with ``pip`` by using:
 
 Now, running Nionswift as ``nionswift`` will show you a window called Orsay Tools.
 
+## Dependencies
+
+OrsaySuite depends on both Hyperspy and Nionswift
+Since both may conflict from time to time, you may want to start on a fresh environment.
+
+``conda create -n hypernion -c nion nionswift nionswift-tool``
+
+Make sure ``nionswift-tool`` is installed, otherwise you may have a conflict with the usage of `Qt5` also used by hyperspy.
+
+Go to your hypernion conda environment:
+
+``conda activate hypernion``
+
+Install Hyperspy
+
+``conda install hyperspy-base -c conda-forge``
+
+Then install OrsaySuite.
+
+
 ## Contributing
 
 Please contact if you wish to contribute to this project.


### PR DESCRIPTION
Modified the readme for a fresh environment installation instructions, and also making sure that nionswift-tool is installed (otherwise, could be conflicting with hyperspy usage of Qt)